### PR TITLE
Add all target *.cpp and *.h to Engine build

### DIFF
--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(Engine SHARED src/Engine/Application.cpp src/Engine/Log.cpp )
+file (GLOB_RECURSE sources CONFIGURE_DEPENDS "*.cpp" "*.h")
+add_library(Engine SHARED ${sources} )
 
 #preprocessor definitions
 add_compile_definitions(GE_BUILD_DLL)


### PR DESCRIPTION
Files are no longer added explicitly but rather built from all files with a .h or a .cpp
This is to speed up development process with different branches and source files (different developers won't need to remember to add sources to the list of targets)