### PR TITLE
Transparency Hotfixed

### DIFF
--- a/Engine/src/Engine/Rendering/Renderer.cpp
+++ b/Engine/src/Engine/Rendering/Renderer.cpp
@@ -57,6 +57,10 @@ namespace Engine
 		
 		glfwSwapInterval(1);
 
+		//Enable transparency
+		glEnable(GL_BLEND);
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
 		//Sets the color of the 'clear' command. This is a dark grey
 		glClearColor(0.1f, 0.1f, 0.1f, 1);
 	}


### PR DESCRIPTION
2 lines enabling transparency in sprites were missing from renderer class during the refactor. I've added them back in.